### PR TITLE
Convert CSS attributes to camelCase + adapt test.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 node_modules
-.idea
-package-lock.json

--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ module.exports = function (str, opts) {
   str.split(';').forEach(function (string) {
     if (string !== '') {
       var attr = string.split(':')
+      while (attr[0].indexOf('-') > 0) { // - is in the attribute name, but is not the first character either
+        var afterDash = attr[0].substring(attr[0].indexOf('-') + 1)
+        afterDash = afterDash.substring(0, 1).toUpperCase() + afterDash.substring(1)
+        attr[0] = attr[0].substring(0, attr[0].indexOf('-')) + afterDash
+      }
       obj[attr[0]] = attr[1]
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-style-2-json",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Convert CSS inline styles to JSON",
   "license": "MIT",
   "repository": "RichardLitt/inline-style-2-json",

--- a/test.js
+++ b/test.js
@@ -5,9 +5,9 @@ var assert = require('assert')
 var inlineStyle2Json = require('./')
 
 it('should ', function () {
-  assert.deepEqual(inlineStyle2Json('position:absolute;h-index:9001;'), {position: 'absolute', 'h-index': '9001'})
+  assert.deepEqual(inlineStyle2Json('position:absolute;h-index:9001;'), {position: 'absolute', 'hIndex': '9001'})
 })
 
 it('should ', function () {
-  assert.deepEqual(inlineStyle2Json('position:absolute;h-index:9001;', {'stringify': true}), '{"position":"absolute","h-index":"9001"}')
+  assert.deepEqual(inlineStyle2Json('position:absolute;h-index:9001;', {'stringify': true}), '{"position":"absolute","hIndex":"9001"}')
 })


### PR DESCRIPTION
When applying CSS style, react now prefers when the attribute names are camelCase, as seen on the following screenshot:

![image](https://user-images.githubusercontent.com/15699766/34171475-69bf2252-e4bc-11e7-8213-605c54cd9c6b.png)

By implementing a loop that recursively checks for the first occurence of "-" in the attribute name and automatically removing that "-" and replacing the next lowercase character by an uppercase character, this issue can be easily fixed by the following code:

```javascript
while (attr[0].indexOf("-") > 0) { // as long as there is a - in the attribute name (but is not the first character either)
    var afterDash = attr[0].substring(attr[0].indexOf("-")+1); // find the word after the first -
    afterDash = afterDash.substring(0, 1).toUpperCase() + afterDash.substring(1);  // capitalize the first letter of that word
    attr[0] = attr[0].substring(0, attr[0].indexOf("-")) + afterDash; // remove the -
}
```

I have implemented and tested the feature.